### PR TITLE
✨feature: 인증 미들웨어 구성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,18 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Spring Boot Starter WebFlux (WebClient 사용을 위한 의존성 추가) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Starter Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
         <!-- Database (MySQL) -->
         <dependency>
             <groupId>mysql</groupId>
@@ -36,6 +48,12 @@
             <version>8.0.32</version>
         </dependency>
 
+        <!-- Hibernate Validator (Bean Validation Provider) 추가 -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.2.0.Final</version>
+        </dependency>
 
         <!-- Lombok (For reducing boilerplate code) -->
         <dependency>

--- a/src/main/java/com/hiccproject/moaram/config/AllowedUrlsConfig.java
+++ b/src/main/java/com/hiccproject/moaram/config/AllowedUrlsConfig.java
@@ -1,0 +1,21 @@
+package com.hiccproject.moaram.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "app")
+public class AllowedUrlsConfig {
+
+    private List<String> allowedUrls;
+
+    public List<String> getAllowedUrls() {
+        return allowedUrls;
+    }
+
+    public void setAllowedUrls(List<String> allowedUrls) {
+        this.allowedUrls = allowedUrls;
+    }
+}

--- a/src/main/java/com/hiccproject/moaram/config/KakaoAuthFilter.java
+++ b/src/main/java/com/hiccproject/moaram/config/KakaoAuthFilter.java
@@ -1,0 +1,62 @@
+package com.hiccproject.moaram.config;
+
+import com.hiccproject.moaram.dto.KakaoUserInfoDto;
+import com.hiccproject.moaram.exception.InvalidTokenException;
+import com.hiccproject.moaram.service.KakaoAuthService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class KakaoAuthFilter extends OncePerRequestFilter {
+
+    private final KakaoAuthService kakaoAuthService;
+
+    public KakaoAuthFilter(KakaoAuthService kakaoAuthService) {
+        this.kakaoAuthService = kakaoAuthService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null) {
+            try {
+                // Token을 검증하고 사용자 정보를 가져옵니다.
+                KakaoUserInfoDto userInfo = kakaoAuthService.validateTokenAndGetUser(token);
+
+                // 사용자 정보를 기반으로 인증 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userInfo, null, null);
+
+                // SecurityContextHolder에 인증 정보를 설정하여 인증된 상태로 처리하도록 합니다.
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                // 요청의 "userInfo" 속성에 사용자 정보 저장
+                request.setAttribute("userInfo", userInfo);
+
+            } catch (InvalidTokenException e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hiccproject/moaram/config/OpenApiConfig.java
+++ b/src/main/java/com/hiccproject/moaram/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.hiccproject.moaram.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "Moaram API", version = "v1"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "OAuth 2.0"
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/hiccproject/moaram/config/SecurityConfig.java
+++ b/src/main/java/com/hiccproject/moaram/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.hiccproject.moaram.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final KakaoAuthFilter kakaoAuthFilter;
+    private final AllowedUrlsConfig allowedUrlsConfig;
+
+    public SecurityConfig(KakaoAuthFilter kakaoAuthFilter, AllowedUrlsConfig allowedUrlsConfig) {
+        this.kakaoAuthFilter = kakaoAuthFilter;
+        this.allowedUrlsConfig = allowedUrlsConfig;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(allowedUrlsConfig.getAllowedUrls().toArray(new String[0])).permitAll()  // 설정된 URL 사용
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                        })
+                )
+                .addFilterBefore(kakaoAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/hiccproject/moaram/controller/UserController.java
+++ b/src/main/java/com/hiccproject/moaram/controller/UserController.java
@@ -1,13 +1,20 @@
 package com.hiccproject.moaram.controller;
 
+import com.hiccproject.moaram.dto.KakaoUserInfoDto;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class UserController {
 
-    @GetMapping("/demo")
+    @GetMapping("/public/demo")
     public String demo() {
         return "demo";
+    }
+
+    @GetMapping("/name")
+    public String name(@RequestAttribute KakaoUserInfoDto userInfo) {
+        return userInfo.getProperties().getNickname();
     }
 }

--- a/src/main/java/com/hiccproject/moaram/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/hiccproject/moaram/dto/KakaoUserInfoDto.java
@@ -1,0 +1,73 @@
+package com.hiccproject.moaram.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+
+    @JsonProperty("id")  // id 필드는 그대로 두고, JSON에서의 "id"를 Java의 "id"로 매핑
+    private Long id;
+
+    @JsonProperty("connected_at")  // JSON의 "connected_at"을 "connectedAt"으로 매핑
+    private String connectedAt;
+
+    private Properties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    // Properties 클래스 정의
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Properties {
+
+        @JsonProperty("nickname")  // nickname 필드 매핑
+        private String nickname;
+    }
+
+    // KakaoAccount 클래스 정의
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoAccount {
+
+        @JsonProperty("profile_nickname_needs_agreement")  // profile_nickname_needs_agreement 필드를 매핑
+        private Boolean profileNicknameNeedsAgreement;
+
+        private Profile profile;
+
+        @JsonProperty("has_email")  // has_email 필드 매핑
+        private Boolean hasEmail;
+
+        @JsonProperty("email_needs_agreement")  // email_needs_agreement 필드 매핑
+        private Boolean emailNeedsAgreement;
+
+        @JsonProperty("is_email_valid")  // is_email_valid 필드 매핑
+        private Boolean isEmailValid;
+
+        @JsonProperty("is_email_verified")  // is_email_verified 필드 매핑
+        private Boolean isEmailVerified;
+
+        @JsonProperty("email")  // email 필드 매핑
+        private String email;
+
+        // Profile 클래스 정의
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Profile {
+
+            @JsonProperty("nickname")  // nickname 필드 매핑
+            private String nickname;
+
+            @JsonProperty("is_default_nickname")  // is_default_nickname 필드를 매핑
+            private Boolean isDefaultNickname;
+        }
+    }
+}

--- a/src/main/java/com/hiccproject/moaram/exception/InvalidTokenException.java
+++ b/src/main/java/com/hiccproject/moaram/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.hiccproject.moaram.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hiccproject/moaram/service/KakaoAuthService.java
+++ b/src/main/java/com/hiccproject/moaram/service/KakaoAuthService.java
@@ -1,0 +1,39 @@
+package com.hiccproject.moaram.service;
+
+import com.hiccproject.moaram.dto.KakaoUserInfoDto;
+import com.hiccproject.moaram.exception.InvalidTokenException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Service
+public class KakaoAuthService {
+
+    private static final String KAKAO_API_URL = "https://kapi.kakao.com/v2/user/me"; // Kakao API 사용자 정보 조회 URL
+
+    private final WebClient webClient;
+
+    // WebClient.Builder를 사용하여 WebClient 인스턴스 생성
+    public KakaoAuthService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl(KAKAO_API_URL).build();
+    }
+
+    public KakaoUserInfoDto validateTokenAndGetUser(String token) {
+        try {
+            // Kakao API 호출 (Bearer Token 인증 방식)
+            String authorizationHeader = "Bearer " + token;
+
+            // GET 요청을 보내기 위한 헤더 설정
+            return webClient.get()
+                    .uri("")
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader) // Authorization 헤더 추가
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoDto.class) // 응답 본문을 KakaoUserInfoDto로 매핑
+                    .block(); // 동기 방식으로 응답 대기
+        } catch (WebClientResponseException e) {
+            // WebClient 예외 처리 (예: 네트워크 문제, Kakao API 응답 오류 등)
+            throw new InvalidTokenException("Failed to validate Kakao Access Token: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
     password: password
   jpa:
     show-sql: true
+    open-in-view: false
 
 ---
 spring:
@@ -23,4 +24,13 @@ spring:
     url: ${RDS_URL}
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
+  jpa:
+    open-in-view: false
 
+---
+app:
+  allowed-urls:
+    - "/"
+    - "/public/**"
+    - "/swagger-ui/**"
+    - "/v3/api-docs/**"


### PR DESCRIPTION
## 🔥Work Description
- ✅ swagger의 모든 엔드포인트에 인증 표시 추가
- ✅ security filter chain에 카카오 토큰 인증 필터 추가
- ✅ KakaoAuthFilter에서 헤더에 담긴 토큰을 webclient를 통한 호출로 검증하고 request에 userinfo 저장
- ✅ web-flux, spring security 관련 의존성 추가

## 🚀Result

<img width="1256" alt="Image" src="https://github.com/user-attachments/assets/6b332969-bd40-4881-a175-8cddf8500ed1" />

## 📝Note
- token없이도 호출하고 싶은 엔드포인트가 있다면, `src/main/resources/application.yml` `allowed-urls`에 추가 필요