### PR TITLE
Feature/#49

### DIFF
--- a/src/main/java/com/hiccproject/moaram/controller/ExhibitionController.java
+++ b/src/main/java/com/hiccproject/moaram/controller/ExhibitionController.java
@@ -73,6 +73,13 @@ public class ExhibitionController {
         }
     }
 
+    @GetMapping("/{exhibitionId}/scrap")
+    public ResponseEntity<?> checkScrapStatus(@PathVariable Long exhibitionId,
+                                              @RequestHeader(value = "Authorization", required = false) String token) {
+        Object result = exhibitionService.getScrapStatus(exhibitionId, token);
+        return ResponseEntity.ok(result);
+    }
+
     @GetMapping("/search")
     public ResponseEntity<Map<String, Object>> searchExhibitions(
             @RequestParam(required = false) LocalDate startDate,

--- a/src/main/java/com/hiccproject/moaram/repository/ExhibitionRepository.java
+++ b/src/main/java/com/hiccproject/moaram/repository/ExhibitionRepository.java
@@ -15,4 +15,8 @@ public interface ExhibitionRepository extends JpaRepository<Exhibition, Long>, J
     Optional<Exhibition> findByIdAndIsAllowedAndDeletedTimeIsNull(Long exhibitionId, Boolean isAllowed);
 
     List<Exhibition> findAll(Specification<Exhibition> spec);
+
+    boolean existsByExhibitionId(Long exhibitionId);
+
+    Optional<Exhibition> findByExhibitionId(Long exhibitionId);
 }

--- a/src/main/java/com/hiccproject/moaram/service/ExhibitionService.java
+++ b/src/main/java/com/hiccproject/moaram/service/ExhibitionService.java
@@ -58,6 +58,20 @@ public class ExhibitionService {
         this.s3Service = s3Service;
     }
 
+    public Object getScrapStatus(Long exhibitionId, String token) {
+        boolean isScrapped = exhibitionRepository.existsByExhibitionId(exhibitionId);
+
+        // 토큰이 없을 경우
+        if (token == null || token.isBlank()) {
+            return isScrapped ? "scrap" : false;
+        }
+
+        // 토큰이 호출될 경우
+        return exhibitionRepository.findByExhibitionId(exhibitionId)
+                .<Object>map(exhibition -> exhibition)
+                .orElse(true);
+    }
+
     @Transactional
     public Exhibition createExhibition(CreateExhibitionDto dto, MultipartFile image, KakaoUserInfoDto userInfo) throws IOException {
         University university = universityRepository.findById(dto.getUniversityId())


### PR DESCRIPTION
Feat: 스크랩 여부 표시
- 토큰 여부에 따라 스크랩 상태 반환
- ExhibitionService에 getScrapStatus() 추가
- ExhibitionController에 /api/exhibition/{exhibitionId}/scrap API 추가
- ExhibitionRepository에 스크랩 조회 기능 추가
- 호출 과정에서 오류가 생겨 현재 고치는 중
#49 